### PR TITLE
Add --no-auth option to consumer

### DIFF
--- a/consumer.yml
+++ b/consumer.yml
@@ -8,6 +8,7 @@ services:
       - PYTHONUNBUFFERED=1
       - KEYFILE=docker/consumer_keyfile
       - PASSWORD=password
+      - CHAIN=home
     command:
       - "dockerize"
       - "-wait"
@@ -22,6 +23,7 @@ services:
       - "--polyswarmd-addr"
       - "polyswarmd:31337"
       - "--insecure-transport"
+      - "--no-auth"
   redis:
     image: "redis"
     environment:


### PR DESCRIPTION
Must use new --no-auth option to allow api-key free submissions in orchestration